### PR TITLE
48: Node and user add path aliases.

### DIFF
--- a/modules/features/manatime_feature_clients/manatime_feature_clients.info
+++ b/modules/features/manatime_feature_clients/manatime_feature_clients.info
@@ -6,6 +6,7 @@ version = 7.x-1.2
 dependencies[] = ctools
 dependencies[] = features
 dependencies[] = list
+dependencies[] = manatime_feature_config
 dependencies[] = manatime_feature_field_bases
 dependencies[] = options
 dependencies[] = strongarm

--- a/modules/features/manatime_feature_clients/manatime_feature_clients.install
+++ b/modules/features/manatime_feature_clients/manatime_feature_clients.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Install some functions for clients feature.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function manatime_feature_clients_install() {
+  manatime_feature_config_add_path_alias('node/add/clients', 'clients/add');
+}

--- a/modules/features/manatime_feature_config/manatime_feature_config.info
+++ b/modules/features/manatime_feature_config/manatime_feature_config.info
@@ -1,0 +1,8 @@
+name = Manatime config feature
+core = 7.x
+package = manatime
+version = 7.x-1.0
+dependencies[] = path
+dependencies[] = pathauto
+features[features_api][] = api:2
+project path = sites/all/modules/features

--- a/modules/features/manatime_feature_config/manatime_feature_config.module
+++ b/modules/features/manatime_feature_config/manatime_feature_config.module
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @file
+ * Containts some functions for the site configuration.
+ */
+
+/**
+ * Function that create the path aliases.
+ */
+function manatime_feature_config_add_path_alias($source, $alias) {
+  $path = array(
+    'source' => $source,
+    'alias' => $alias,
+  );
+  path_save($path);
+}

--- a/modules/features/manatime_feature_projects/manatime_feature_projects.info
+++ b/modules/features/manatime_feature_projects/manatime_feature_projects.info
@@ -7,6 +7,7 @@ dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = inline_entity_form
 dependencies[] = list
+dependencies[] = manatime_feature_config
 dependencies[] = manatime_feature_field_bases
 dependencies[] = options
 dependencies[] = strongarm

--- a/modules/features/manatime_feature_projects/manatime_feature_projects.install
+++ b/modules/features/manatime_feature_projects/manatime_feature_projects.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Install some functions for projects feature.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function manatime_feature_projects_install() {
+  manatime_feature_config_add_path_alias('node/add/projects', 'projects/add');
+}

--- a/modules/features/manatime_feature_tasks/manatime_feature_tasks.info
+++ b/modules/features/manatime_feature_tasks/manatime_feature_tasks.info
@@ -7,6 +7,7 @@ dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = inline_entity_form
 dependencies[] = list
+dependencies[] = manatime_feature_config
 dependencies[] = manatime_feature_field_bases
 dependencies[] = options
 dependencies[] = page_manager

--- a/modules/features/manatime_feature_tasks/manatime_feature_tasks.install
+++ b/modules/features/manatime_feature_tasks/manatime_feature_tasks.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Install some functions for tasks feature.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function manatime_feature_tasks_install() {
+  manatime_feature_config_add_path_alias('node/add/tasks', 'tasks/add');
+}

--- a/modules/features/manatime_feature_users/manatime_feature_users.info
+++ b/modules/features/manatime_feature_users/manatime_feature_users.info
@@ -3,6 +3,7 @@ core = 7.x
 package = manatime
 version = 7.x-1.3
 dependencies[] = features
+dependencies[] = manatime_feature_config
 dependencies[] = manatime_feature_field_bases
 dependencies[] = number
 dependencies[] = views

--- a/modules/features/manatime_feature_users/manatime_feature_users.install
+++ b/modules/features/manatime_feature_users/manatime_feature_users.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Install some functions for users feature.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function manatime_feature_users_install() {
+  manatime_feature_config_add_path_alias('admin/people/create', 'users/add');
+}

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -56,6 +56,7 @@ $conf['master_modules']['base'] = array(
 
   // Custom modules.
   'manatime_feature_clients',
+  'manatime_feature_config',
   'manatime_feature_field_bases',
   'manatime_feature_projects',
   'manatime_feature_tasks',

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,5 @@
 box: linode/lamp
 no-response-timeout: 10
-command-timeout: 10
 build:
     steps:
     - script:


### PR DESCRIPTION
**Steps to tests**
- Check if the followings path aliases are working:
  - clients/add
  - projects/add
  - tasks/add
  - users/add
- Check if the dependencies were added to the clients, projects, tasks and users features.
- Check if the comments of the file .module feature are correctly. 
- Check the files of the manatime_feature_config are right.
- Verify the feature manatime_feature_config was added correctly to settings.php.

[Issue link](https://github.com/ManatiCR/manatime/issues/48)
